### PR TITLE
Handle 'or' in highlight search string

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -23,7 +23,12 @@ function M.match(str, pattern)
 
   local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
   if #m > 1 and m[2] then
-    local kw = m[2]
+    local kw = ''
+    if m[2] == '' and m[3] then
+        kw = m[3]
+    else
+        kw = m[2]
+    end
     local start = str:find(kw)
     return start, start + #kw, kw
   end


### PR DESCRIPTION
This allows using multiple patterns e.g. for Doxygen todos
Closes #30

<img width="260" alt="example" src="https://user-images.githubusercontent.com/10778249/125197467-00c77c80-e21b-11eb-8822-9169de1a274b.png">

It would also be nice to have the highlighted text align with the default (highlight leading space and don't highlight trailing space) but I wasn't sure how to make that happen. I could add that if you point me in the right direction.