### PR TITLE
chore: make it possible to disable warnings when searching

### DIFF
--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -34,6 +34,7 @@ function M.search(cb, opts)
   opts = opts or {}
   opts.cwd = opts.cwd or "."
   opts.cwd = vim.fn.fnamemodify(opts.cwd, ":p")
+  opts.disable_not_found_warnings = opts.disable_not_found_warnings or false
   if not Config.loaded then
     Util.error("todo-comments isn't loaded. Did you run setup()?")
     return
@@ -62,7 +63,7 @@ function M.search(cb, opts)
           local error = table.concat(j:stderr_result(), "\n")
           Util.error(command .. " failed with code " .. code .. "\n" .. error)
         end
-        if code == 1 then
+        if code == 1 and opts.disable_not_found_warnings ~= true then
           Util.warn("no todos found")
         end
         local lines = j:result()


### PR DESCRIPTION
Hi thanks a lot for the plugin! I'm building a plugin that uses this internally, it's calling the `search` function to obtain the processed list of TODOs

One thing that I noticed is that when there are no TODOs found it always prints a warning to messages, which is a bit annoying for my plugin that periodically updates its internal data.

Are you interested in this quick fix I made to resolve this? I'm not very familiar with this plugin's code so if there is a better way to do it I will be gladly accommodate my code.

![image](https://user-images.githubusercontent.com/1891977/130364200-513b5d95-b26d-46e4-a8c6-c092cbbbd71c.png)
