### PR TITLE
fix: update README to 0.6 diagnostic hl

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Todo comes with the following defaults:
   -- list of named colors where we try to extract the guifg from the
   -- list of hilight groups or use the hex color if hl not found as a fallback
   colors = {
-    error = { "LspDiagnosticsDefaultError", "ErrorMsg", "#DC2626" },
-    warning = { "LspDiagnosticsDefaultWarning", "WarningMsg", "#FBBF24" },
-    info = { "LspDiagnosticsDefaultInformation", "#2563EB" },
-    hint = { "LspDiagnosticsDefaultHint", "#10B981" },
+    error = { "DiagnosticError", "ErrorMsg", "#DC2626" },
+    warning = { "DiagnosticWarning", "WarningMsg", "#FBBF24" },
+    info = { "DiagnosticInfo", "#2563EB" },
+    hint = { "DiagnosticHint", "#10B981" },
     default = { "Identifier", "#7C3AED" },
   },
   search = {


### PR DESCRIPTION
The README had hl groups in default that are no longer true. Change them
to the actual default values.
