### PR TITLE
feat: add wide_end keyword highlight mode

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -133,6 +133,9 @@ function M.highlight(buf, first, last, _event)
       -- tag highlights
       if hl.keyword == "wide" then
         add_highlight(buf, Config.ns, hl_bg, lnum, math.max(start - 1, 0), finish + 1)
+	  elseif hl.keyword == "wide_end" then
+        finish = finish + 1
+        add_highlight(buf, Config.ns, hl_bg, lnum, start, finish)
       elseif hl.keyword == "bg" then
         add_highlight(buf, Config.ns, hl_bg, lnum, start, finish)
       elseif hl.keyword == "fg" then


### PR DESCRIPTION
Similar to wide mode, but does not highlight the character before the keyword.
It only highlights the keyword and the character after it.