### PR TITLE
Allow specifying wide_fg

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Todo comes with the following defaults:
   -- * after: highlights after the keyword (todo text)
   highlight = {
     before = "", -- "fg" or "bg" or empty
-    keyword = "wide", -- "fg", "bg", "wide","wide_bg", "wide_fg" or empty. (wide and wide_bg is the same as bg, but will also highlight surrounding characters, wide_fg acts accordingly but with fg)
+    keyword = "wide", -- "fg", "bg", "wide", "wide_bg", "wide_fg" or empty. (wide and wide_bg is the same as bg, but will also highlight surrounding characters, wide_fg acts accordingly but with fg)
     after = "fg", -- "fg" or "bg" or empty
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlightng (vim regex)
     comments_only = true, -- uses treesitter to match keywords in comments only

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Todo comes with the following defaults:
   -- * after: highlights after the keyword (todo text)
   highlight = {
     before = "", -- "fg" or "bg" or empty
-    keyword = "wide", -- "fg", "bg", "wide" or empty. (wide is the same as bg, but will also highlight surrounding characters)
+    keyword = "wide", -- "fg", "bg", "wide","wide_bg", "wide_fg" or empty. (wide and wide_bg is the same as bg, but will also highlight surrounding characters, wide_fg acts accordingly but with fg)
     after = "fg", -- "fg" or "bg" or empty
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlightng (vim regex)
     comments_only = true, -- uses treesitter to match keywords in comments only

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -131,8 +131,10 @@ function M.highlight(buf, first, last, _event)
       end
 
       -- tag highlights
-      if hl.keyword == "wide" then
+      if hl.keyword == "wide" or hl.keyword == "wide_bg" then
         add_highlight(buf, Config.ns, hl_bg, lnum, math.max(start - 1, 0), finish + 1)
+      elseif hl.keyword == "wide_fg" then
+        add_highlight(buf, Config.ns, hl_fg, lnum, math.max(start - 1, 0), finish + 1)
       elseif hl.keyword == "bg" then
         add_highlight(buf, Config.ns, hl_bg, lnum, start, finish)
       elseif hl.keyword == "fg" then


### PR DESCRIPTION
This PR adds the possibility to specify `wide_fg` and `wide_bg` for the keyword highlight. It keeps the default `wide` functionality in place for backwards compatibility. 

While it does not seem to make sense with the default config, because the surrounding characters are whitespace, I use `[` and `]` to surround my keywords and wanted them to be styled like the keyword itself.