### PR TITLE
Add toggle function

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -304,4 +304,11 @@ function M.start()
   end
 end
 
+function M.toggle()
+  if M.enabled then
+    M.stop() return
+  end
+  M.start()
+end
+
 return M

--- a/lua/todo-comments/init.lua
+++ b/lua/todo-comments/init.lua
@@ -17,4 +17,8 @@ function M.enable()
   require("todo-comments.highlight").start()
 end
 
+function M.switch()
+  require("todo-comments.highlight").toggle()
+end
+
 return M


### PR DESCRIPTION
I found myself in situations where having comment highlighting disabled was the preferred choice. Didn't happened often, but it happened. So I added a simple toggle function

To really have highlighting disabled, I need to say that VIM and treesitter are also adding highlighting to some keywords. Therefore, one should set `vim.cmd [[hi! link Todo Comment]]`. Lastly, if your treesitter config contains `ensure_installed = "all"`, add `ignore_install = { "comment" }`. Those can be the defaults for a nvim config that's using the todo-comments.nvim plugin. As it handles highlighting makes it obsolete to add layer on top of layer of comment highlighting.
