### PR TITLE
avoid E5108 after pressing q:

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -191,6 +191,10 @@ function M.is_valid_win(win)
   if not vim.api.nvim_win_is_valid(win) then
     return false
   end
+  -- avoid E5108 after pressing q:
+  if vim.fn.getcmdwintype() ~= "" then
+    return false
+  end
   -- dont do anything for floating windows
   if M.is_float(win) then
     return false


### PR DESCRIPTION
Fixing bug to avoid E5105 after accidentally pressing `q:` instead of `:q`. Please find more information in this [subreddit](https://www.reddit.com/r/neovim/comments/uqoj50/e5108_after_pressing_q/).