### PR TITLE
feat: accept argument to filter keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,18 @@ Todo comes with the following defaults:
 
 Todos are highlighted in all regular files.
 
-Each of the commands below can have an options argument to specify the directory to search for comments, like:
+Each of the commands below accept the following arguments:
+
+- `cwd` - Specify the directory to search for comments, like:
 
 ```vim
 :TodoTrouble cwd=~/projects/foobar
+```
+
+- `keywords` - Comma separated list of keywords to filter results by. Keywords are case-sensitive.
+
+```vim
+:TodoTelescope keywords=TODO,FIX
 ```
 
 ### 🔎 `:TodoQuickFix`

--- a/lua/telescope/_extensions/todo-comments.lua
+++ b/lua/telescope/_extensions/todo-comments.lua
@@ -9,11 +9,24 @@ local Config = require("todo-comments.config")
 local Highlight = require("todo-comments.highlight")
 local make_entry = require("telescope.make_entry")
 
+local function keywords_filter(opts_keywords)
+  assert(not opts_keywords or type(opts_keywords) == "string", "'keywords' must be a comma separated string or nil")
+  local all_keywords = vim.tbl_keys(Config.keywords)
+  if not opts_keywords then
+    return all_keywords
+  end
+  local filters = vim.split(opts_keywords, ",")
+  return vim.tbl_filter(function(kw)
+    return vim.tbl_contains(filters, kw)
+  end, all_keywords)
+end
+
 local function todo(opts)
   opts = opts or {}
   opts.vimgrep_arguments = { Config.options.search.command }
   vim.list_extend(opts.vimgrep_arguments, Config.options.search.args)
-  opts.search = Config.search_regex
+
+  opts.search = Config.search_regex(keywords_filter(opts.keywords))
   opts.prompt_title = "Find Todo"
   opts.use_regex = true
   local entry_maker = make_entry.gen_from_vimgrep(opts)

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -97,13 +97,19 @@ function M._setup()
     end
   end
 
-  local tags = table.concat(vim.tbl_keys(M.keywords), "|")
-  M.search_regex = M.options.search.pattern:gsub("KEYWORDS", tags)
+  local function tags(keywords)
+    return table.concat(keywords or vim.tbl_keys(M.keywords), "|")
+  end
+
+  function M.search_regex(keywords)
+    return M.options.search.pattern:gsub("KEYWORDS", tags(keywords))
+  end
+
   M.hl_regex = {}
   local patterns = M.options.highlight.pattern
   patterns = type(patterns) == "table" and patterns or { patterns }
   for _, p in pairs(patterns) do
-    p = p:gsub("KEYWORDS", tags)
+    p = p:gsub("KEYWORDS", tags())
     table.insert(M.hl_regex, p)
   end
   M.colors()

--- a/plugin/todo.vim
+++ b/plugin/todo.vim
@@ -1,5 +1,5 @@
 
-command! -nargs=* TodoQuickFix lua require("todo-comments.search").setqflist(<f-args>)
-command! -nargs=* TodoLocList lua require("todo-comments.search").setloclist(<f-args>)
+command! -nargs=* TodoQuickFix lua require("todo-comments.search").setqflist(<q-args>)
+command! -nargs=* TodoLocList lua require("todo-comments.search").setloclist(<q-args>)
 command! -nargs=* TodoTelescope Telescope todo-comments todo <args>
 command! -nargs=* TodoTrouble Trouble todo <args>


### PR DESCRIPTION
With this change one can use

```
:TodoTrouble keywords=TODO,FIX
```

to display only the keywords given in the comma separated list.

Fixes #102.