### PR TITLE
feat: add config option to set gui style

### DIFF
--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -29,6 +29,10 @@ local defaults = {
     PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
     NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
   },
+  gui_style = {
+    fg = false, -- If true, fg highlight will use gui=BOLD. If false, use gui=NONE.
+    bg = true,  -- If true, bg highlight will use gui=BOLD, If false, use gui=NONE.
+  },
   merge_keywords = true, -- when true, custom keywords will be merged with the defaults
   -- highlighting of the line containing the todo comment
   -- * before: highlights before the keyword (typically comment characters)
@@ -127,6 +131,8 @@ function M.colors()
   local fg_light = Util.is_dark(normal.foreground or "#ffffff") and normal.background or normal.foreground
   fg_dark = fg_dark or "#000000"
   fg_light = fg_light or "#ffffff"
+  local fg_gui = M.options.gui_style.fg and 'BOLD' or 'NONE'
+  local bg_gui = M.options.gui_style.bg and 'BOLD' or 'NONE'
 
   local sign_hl = Util.get_hl("SignColumn")
   local sign_bg = (sign_hl and sign_hl.background) and sign_hl.background or "NONE"
@@ -158,8 +164,8 @@ function M.colors()
     end
     local fg = Util.is_dark(hex) and fg_light or fg_dark
 
-    vim.cmd("hi def TodoBg" .. kw .. " guibg=" .. hex .. " guifg=" .. fg .. " gui=bold")
-    vim.cmd("hi def TodoFg" .. kw .. " guibg=NONE guifg=" .. hex .. " gui=NONE")
+    vim.cmd("hi def TodoBg" .. kw .. " guibg=" .. hex .. " guifg=" .. fg .. " gui=" .. bg_gui)
+    vim.cmd("hi def TodoFg" .. kw .. " guibg=NONE guifg=" .. hex .. " gui=" .. fg_gui)
     vim.cmd("hi def TodoSign" .. kw .. " guibg=" .. sign_bg .. " guifg=" .. hex .. " gui=NONE")
   end
 end

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -30,8 +30,8 @@ local defaults = {
     NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
   },
   gui_style = {
-    fg = false, -- If true, fg highlight will use gui=BOLD. If false, use gui=NONE.
-    bg = true,  -- If true, bg highlight will use gui=BOLD, If false, use gui=NONE.
+    fg = "NONE", -- The gui style to use for the fg highlight group.
+    bg = "BOLD", -- The gui style to use for the bg highlight group.
   },
   merge_keywords = true, -- when true, custom keywords will be merged with the defaults
   -- highlighting of the line containing the todo comment
@@ -131,8 +131,8 @@ function M.colors()
   local fg_light = Util.is_dark(normal.foreground or "#ffffff") and normal.background or normal.foreground
   fg_dark = fg_dark or "#000000"
   fg_light = fg_light or "#ffffff"
-  local fg_gui = M.options.gui_style.fg and 'BOLD' or 'NONE'
-  local bg_gui = M.options.gui_style.bg and 'BOLD' or 'NONE'
+  local fg_gui = M.options.gui_style.fg
+  local bg_gui = M.options.gui_style.bg
 
   local sign_hl = Util.get_hl("SignColumn")
   local sign_bg = (sign_hl and sign_hl.background) and sign_hl.background or "NONE"


### PR DESCRIPTION
Currently, the gui style of both fg and bg highlight groups are hardcoded so that fg defaults to gui=NONE, and bg defaults to gui=BOLD. This prevents you from being able to customize the gui style, such as using bold,underline with the fg style.

This PR adds the ability to control the gui style of both the foreground and background highlight groups using the normal gui=... syntax, such as:

```lua
  gui_style = {
    fg = "NONE", -- No gui style for fg highlight group
    bg = "bold,underline", -- Use underlined bold style for bg highlight group
  },
```