### PR TITLE
Check that buffer is loaded

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -275,7 +275,9 @@ function M.stop()
   M.wins = {}
   vim.fn.sign_unplace("todo-signs")
   for buf, _ in pairs(M.bufs) do
-    vim.api.nvim_buf_clear_namespace(buf, Config.ns, 0, -1)
+    if vim.api.nvim_buf_is_loaded(buf) then
+      vim.api.nvim_buf_clear_namespace(buf, Config.ns, 0, -1)
+    end
   end
   M.bufs = {}
 end


### PR DESCRIPTION
Fixes #99 
Fixes #93 

I've been sporadically getting the following message:

```
packer.nvim: Error running config for todo-comments.nvim: ...start/todo-comments.nvim/lua/todo-comments/highlight.lua:279: Invalid buffer id: 1
```

When it happens is fairly sporadic, sometimes when running `PackerCompile`, sometimes when just saving a file, not really sure I know the exact pattern.

This prevents the error by first checking if the buffer is loaded before attempting to run `nvim_buf_clear_namespace`.  There very well may be a better solution than this, but this at least get's rid of the error which has been quite annoying.