### PR TITLE
fix: avoid error when current_win is an invalid win.

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -174,6 +174,9 @@ function M.highlight_win(win, force)
   end
 
   local current_win = vim.api.nvim_get_current_win()
+  if not M.is_valid_win(current_win) then
+	return
+  end
   vim.api.nvim_set_current_win(win)
 
   local buf = vim.api.nvim_win_get_buf(win)


### PR DESCRIPTION
Below configuration meets an error when use `Telescope` after vim starts up because `current_win` is not a valid win.
`todo-comments` is loaded when `BufNewFile` or `BufRead` events happen.
`telescop.nvim` is loaded when I use the command `Telescope`.
There is neither a start-up plugin nor loading a session.