### PR TITLE
fixed: When todo-comments.nvim as optional and report an error 

### DIFF
--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -80,9 +80,13 @@ M._options = nil
 
 function M.setup(options)
   M._options = options
-  vim.defer_fn(function()
+  if vim.api.nvim_get_vvar("vim_did_enter") == 0 then
+    vim.defer_fn(function()
+      M._setup()
+    end, 0)
+  else
     M._setup()
-  end, 0)
+  end
 end
 
 function M._setup()


### PR DESCRIPTION
When `todo-comments.nvim` is optional, the first time it is used `vim.defer_fn` does not block and returns immediately, causing later code to read config.options as nil.