### PR TITLE
Allow users to use multiline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Todo comes with the following defaults:
     after = "fg", -- "fg" or "bg" or empty
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlightng (vim regex)
     comments_only = true, -- uses treesitter to match keywords in comments only
+    multiline = true, -- higlights multiple-line blocks associated with a keyword, requires 'comments_only' to be true
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
   },

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -80,14 +80,13 @@ local defaults = {
 M._options = nil
 
 function M.setup(options)
-  M._options = options
   vim.defer_fn(function()
-    M._setup()
+    M._setup(options)
   end, 0)
 end
 
-function M._setup()
-  M.options = vim.tbl_deep_extend("force", {}, defaults, M.options or {}, M._options or {})
+function M._setup(options)
+  M.options = vim.tbl_deep_extend("force", {}, defaults, M.options or {}, options)
 
   -- -- keywords should always be fully overriden
   if M._options and M._options.keywords and M._options.merge_keywords == false then

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -47,6 +47,7 @@ local defaults = {
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlightng (vim regex)
     -- pattern = { [[.*<(KEYWORDS)\s*:]], [[.*\@(KEYWORDS)\s*]] }, -- pattern used for highlightng (vim regex)
     comments_only = true, -- uses treesitter to match keywords in comments only
+    multiline = true, -- higlights multiple-line blocks associated with a keyword, requires 'comments_only' to be true
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
   },

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -119,9 +119,7 @@ function M.highlight(buf, first, last, _event)
       end
       last_match = nil
     else
-      if #line == 0 then
-        last_match = nil
-      elseif Config.options.highlight.comments_only and Config.options.highlight.multiline and not M.is_quickfix(buf) and M.is_comment(buf, lnum) == true and last_match ~= nil then
+      if Config.options.highlight.comments_only and Config.options.highlight.multiline and not M.is_quickfix(buf) and M.is_comment(buf, lnum) == true and last_match ~= nil then
         kw = last_match["kw"]
         start = last_match["start"]
         finish = last_match["finish"]

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -17,6 +17,11 @@ M.wins = {}
 
 -- WARNING: with space immediately after
 
+-- FIXME: prevent trailing comments from being flagged
+local _dont_delete_me_this_is_a_test = {
+    blah = true -- trailing comment
+}
+
 -- todo: fooo
 -- @TODO foobar
 -- @hack foobar
@@ -120,6 +125,8 @@ function M.highlight(buf, first, last, _event)
         kw = last_match["kw"]
         start = last_match["start"]
         finish = last_match["finish"]
+      else
+        last_match = nil
       end
     end
 


### PR DESCRIPTION
Probably not the cleanest logic but it seems to work

Add logic to do multiline highlighting when 'comments_only' config option is enabled, and a new config option to control this behaviour (default is enabled)