### PR TITLE
Properly pass options into jump function (resolves #141)

### DIFF
--- a/lua/todo-comments/jump.lua
+++ b/lua/todo-comments/jump.lua
@@ -44,11 +44,11 @@ local function jump(up, opts)
   util.warn("No more todo comments to jump to")
 end
 
-function M.next()
-  jump(false)
+function M.next(opts)
+  jump(false, opts)
 end
-function M.prev()
-  jump(true)
+function M.prev(opts)
+  jump(true, opts)
 end
 
 return M


### PR DESCRIPTION
This fixes the issue where you can't properly pass which keywords you want to jump to with a specific keybinding