### PR TITLE
[Fix]: Don't mark all lines in buffer as dirty, only visible lines

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -97,8 +97,8 @@ function M.get_state(buf)
 end
 
 function M.redraw(buf, first, last)
-  first = math.max(first - Config.options.highlight.multiline_context, 0)
-  last = math.max(last + Config.options.highlight.multiline_context, vim.api.nvim_buf_line_count(buf))
+  first = math.max(vim.fn.line('w0') - Config.options.highlight.multiline_context, 0)
+  last = math.min(vim.fn.line('w$') + Config.options.highlight.multiline_context, vim.api.nvim_buf_line_count(buf))
   local state = M.get_state(buf)
   for i = first, last do
     state.dirty[i] = true


### PR DESCRIPTION
In the original code all of the lines in the current buffer are marked as dirty. I don't know whether filetypes which have treesitter support suffer from this too but for a big buffer and a filetype such as xml this gets very slow to the point where it blocks neovim for a while until it's done. This happens too after the latest performance commits but I don't know if they were relevant. 

This pr is a simple change which makes it so that only the currently visible lines in the buffer are redrawn. I'm opening this pr as a draft because I'm only using a very limited subset of this plugin's features so I don't know if anything besides simply highlighting is impacted by this. Consider it a issue report with an included preliminary fix.

If you're interested I've got a stack trace too, although the only thing it really shows is `todo-comments.highlight.match` being called 45000 times for every line of my large xml document.

Other than that, hartstikke bedankt for all the fantastic work Folke! Greetings from up north :)