### PR TITLE
Enable the use of regex for keywords

### DIFF
--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -108,14 +108,22 @@ function M._setup()
   for kw, opts in pairs(M.options.keywords) do
     M.keywords[kw] = kw
     M.keyword_regex[kw] = opts.regex
-    for _, alt in pairs(opts.alt or {}) do
-      M.keywords[alt] = kw
+    for idx, alt in pairs(opts.alt or {}) do
+      if type(idx) == "number" then
+        M.keywords[alt] = kw
+      else
+        M.keywords[idx] = kw
+        if type(alt) == "string" then
+          M.keyword_regex[idx] = alt
+        else
+          M.keyword_regex[idx] = alt.regex
+        end
+      end
     end
   end
 
   local function tags(keywords)
     local kws = {}
-    -- local kws = keywords or vim.tbl_keys(M.keywords)
 
     for _, kw in pairs(keywords or {}) do
       local possible_regex = M.keyword_regex[kw]

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -43,12 +43,12 @@ function M.match(str, patterns)
     patterns = { patterns }
   end
 
-  for _, pattern in pairs(patterns) do
+  for kw, pattern in pairs(patterns) do
     local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
     if #m > 1 and m[2] then
-      local kw = m[2]
-      local start = str:find(kw)
-      return start, start + #kw, kw
+      local txt = m[2]
+      local start = vim.fn.stridx(str, txt)
+      return start, start + #txt, kw
     end
   end
 end


### PR DESCRIPTION
The ability to do regex search for text and have it pop up in the `:TodoTrouble` or `:TodoTelescope` is very useful for things like Markdown todo lists. In general, the same configuration exists. If you want to make a keyword specifically use regular expression, then assign it to a regular expression. e.g. 
```
      alt = {
        TODO = [=[[*-]\s\[.?\]]=],
        "WIP"
      },
```
if you want WIP to be a regular expression, then use `WIP = [[<my regex here>]]`



The overall configuration looks would look something like this.
```
 keywords = {
    FIX = {
      icon = " ",
      color = "error", -- can be a hex color, or a named color (see below)
      alt = { "FIXME", "BUG", "FIXIT", "FIX", "ISSUE" },
      -- signs = false, -- configure signs for some keywords individually
    },
    TODO = {
      icon = " ",
      color = "info",
      alt = {
        TODO = [=[[*-]\s\[.?\]]=],
        "WIP"
      },
    },
    HACK = { icon = " ", color = "warning" },
    WARN = { icon = " ", color = "warning", alt = { "WARNING", "XXX" } },
    PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
    NOTE = { icon = " ", color = "hint", alt = { "INFO", "HLE", "Q" } },
  },
```