### PR TITLE
feat(highlight): allow highlighting the full pattern

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -46,9 +46,10 @@ function M.match(str, patterns)
   for _, pattern in pairs(patterns) do
     local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
     if #m > 1 and m[2] then
-      local kw = m[2]
-      local start = str:find(kw)
-      return start, start + #kw, kw
+      local matched = m[1]
+      local kw_only = m[2]
+      local start = str:find(matched, 1, true)
+      return start, start + #matched - 1, kw_only
     end
   end
 end


### PR DESCRIPTION
this will allow highlighting `TODO(author):`

```lua
highlight = {
  pattern = [[(KEYWORDS)\s*(\([^\)]*\))?:]],
},
```

![image](https://user-images.githubusercontent.com/40219740/218302992-3ab3cd95-74c0-4313-9870-d2781238a42c.png)

fixes https://github.com/folke/todo-comments.nvim/issues/10
fixes https://github.com/folke/todo-comments.nvim/issues/179