### PR TITLE
add fallback for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ Todo comes with the following defaults:
     pattern = [[\b(KEYWORDS):]], -- ripgrep regex
     -- pattern = [[\b(KEYWORDS)\b]], -- match without the extra colon. You'll likely get false positives
   },
+  fallback_search = {
+    command = "grep",
+    search_args = {
+      "--recursive",
+      "--color=never",
+      "--with-filename",
+      "--line-number",
+      "--binary-files=without-match",
+      "--byte-offset",
+      "--exclude-dir='.*'",
+      "--extended-regexp",
+    },
+    search_pattern = ".*(KEYWORDS):",
+  },
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Todo comes with the following defaults:
       "--extended-regexp",
     },
     search_pattern = ".*(KEYWORDS):",
+    disable_warning = false,
   },
 }
 

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -78,6 +78,20 @@ local defaults = {
     pattern = [[\b(KEYWORDS):]], -- ripgrep regex
     -- pattern = [[\b(KEYWORDS)\b]], -- match without the extra colon. You'll likely get false positives
   },
+  fallback_search = {
+    command = "grep",
+    args = {
+      "--recursive",
+      "--color=never",
+      "--with-filename",
+      "--line-number",
+      "--binary-files=without-match",
+      "--byte-offset",
+      "--exclude-dir='.*'",
+      "--extended-regexp",
+    },
+    pattern = ".*(KEYWORDS):",
+  },
 }
 
 M._options = nil
@@ -119,8 +133,8 @@ function M._setup()
     return table.concat(kws, "|")
   end
 
-  function M.search_regex(keywords)
-    return M.options.search.pattern:gsub("KEYWORDS", tags(keywords))
+  function M.search_regex(keywords, pattern)
+    return pattern:gsub("KEYWORDS", tags(keywords))
   end
 
   M.hl_regex = {}

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -91,6 +91,7 @@ local defaults = {
       "--extended-regexp",
     },
     pattern = ".*(KEYWORDS):",
+    disable_warning = false,
   },
 }
 

--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -67,7 +67,9 @@ function M.search(cb, opts)
   end
 
   if not command_exists and fallback_exists and fallback_command then
-    Util.warn(command .. " was not found on your path, using " .. fallback_command .. " instead.")
+    if Config.options.fallback_search.disable_warning ~= true then
+      Util.warn(command .. " was not found on your path, using " .. fallback_command .. " instead.")
+    end
     command = fallback_command
     search_args = Config.options.fallback_search.args
     search_pattern = Config.options.fallback_search.pattern


### PR DESCRIPTION
This PR implements fallback search, using `grep` by default.

It can be disabled in configuration like this
```lua
fallback_search = {
  command = false,
}
```

I guess there is a better way to call it, rather than "fallback search".