### PR TITLE
feat(telescope): access pickers with plugin_name...

### DIFF
--- a/lua/telescope/_extensions/todo-comments.lua
+++ b/lua/telescope/_extensions/todo-comments.lua
@@ -64,4 +64,4 @@ local function todo(opts)
   pickers.grep_string(opts)
 end
 
-return telescope.register_extension({ exports = { todo = todo } })
+return telescope.register_extension({ exports = { ["todo-comments"] = todo, todo = todo } })


### PR DESCRIPTION
.. see https://github.com/nvim-telescope/telescope.nvim/blob/942fe5faef47b21241e970551eba407bc10d9547/developers.md?plain=1#L322

Before (_Note: left this variant for compatibility_):

```vim
:Telescope todo-comments todo
```

After:

```vim
:Telescope todo-comments
```