### PR TITLE
Add option to not "hide" the colon when 'keyword' highlight is "wide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Todo comes with the following defaults:
     comments_only = true, -- uses treesitter to match keywords in comments only
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
+    colon_in_wide = false, -- when true, the colon is only highlighted with "keyword", otherwise both "keyword" and "after". Only matters when keyword is "wide(_bg)" and after is "fg" or "wide_fg" and "bg", respectively
   },
   -- list of named colors where we try to extract the guifg from the
   -- list of highlight groups or use the hex color if hl not found as a fallback

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -53,6 +53,7 @@ local defaults = {
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
     throttle = 200,
+    colon_in_wide = false, -- when true, the colon is only highlighted with "keyword", otherwise both "keyword" and "after"
   },
   -- list of named colors where we try to extract the guifg from the
   -- list of hilight groups or use the hex color if hl not found as a fallback

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -230,6 +230,10 @@ function M.highlight(buf, first, last, _event)
         end
       end
 
+      if not hl.colon_in_wide then
+        afteroffset = 0
+      end
+
       -- after highlights
       if hl.after == "fg" then
         add_highlight(buf, Config.ns, hl_fg, lnum, finish+afteroffset, #line)

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -201,6 +201,7 @@ function M.highlight(buf, first, last, _event)
     if opts then
       start = start - 1
       finish = finish - 1
+      local afteroffset = 0
 
       local hl_fg = "TodoFg" .. kw
       local hl_bg = "TodoBg" .. kw
@@ -217,8 +218,10 @@ function M.highlight(buf, first, last, _event)
 
         -- tag highlights
         if hl.keyword == "wide" or hl.keyword == "wide_bg" then
+          afteroffset = afteroffset + 1
           add_highlight(buf, Config.ns, hl_bg, lnum, math.max(start - 1, 0), finish + 1)
         elseif hl.keyword == "wide_fg" then
+          afteroffset = afteroffset + 1
           add_highlight(buf, Config.ns, hl_fg, lnum, math.max(start - 1, 0), finish + 1)
         elseif hl.keyword == "bg" then
           add_highlight(buf, Config.ns, hl_bg, lnum, start, finish)
@@ -229,9 +232,9 @@ function M.highlight(buf, first, last, _event)
 
       -- after highlights
       if hl.after == "fg" then
-        add_highlight(buf, Config.ns, hl_fg, lnum, finish, #line)
+        add_highlight(buf, Config.ns, hl_fg, lnum, finish+afteroffset, #line)
       elseif hl.after == "bg" then
-        add_highlight(buf, Config.ns, hl_bg, lnum, finish, #line)
+        add_highlight(buf, Config.ns, hl_bg, lnum, finish+afteroffset, #line)
       end
 
       if not is_multiline then


### PR DESCRIPTION
I find it helpful to be able to see the colon after any keywords (though the default wide_bg does look nice). Found out that when the highlighter is configured with a wide-background `keyword` and foreground `after`, the colon will have its background and foreground set to the same color.

It's still the default to hide the colon in the above manner. To make it visible, I added a boolean option to config.highlight called `colon_in_wide`. Please change the naming if you have something that's clearer; I think `colon_in_wide` is a little clunky.

Here's how the options interact (no effect if "keyword" and "after" are both fg or bg):
| keyword | after | colon_in_wide | result |
|--------|--------|--------|--------|
| wide_bg | fg | false | ![image](https://user-images.githubusercontent.com/35613401/236586902-75ad111d-1e00-4c46-8766-5ebeb093f7b4.png) |
| wide_bg | fg | true | ![image](https://user-images.githubusercontent.com/35613401/236586972-77ab0013-6389-4ad8-88e9-159e8ef88a41.png) |
| wide_fg | bg | false | ![image](https://user-images.githubusercontent.com/35613401/236586942-c599087d-5957-467d-aa07-cb90b1e3632a.png) |
| wide_fg | bg | true | ![image](https://user-images.githubusercontent.com/35613401/236587002-85cf6cf9-6227-417a-8330-463840c045ff.png) | 