### PR TITLE
feat: Add option to not override highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Todo comes with the following defaults:
   -- * keyword: highlights of the keyword
   -- * after: highlights after the keyword (todo text)
   highlight = {
+    override = true, -- allow plugin to override highlights
     multiline = true, -- enable multine todo comments
     multiline_pattern = "^.", -- lua pattern to match the next multiline from the start of the matched keyword
     multiline_context = 10, -- extra lines that will be re-evaluated when changing a line

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -40,6 +40,7 @@ local defaults = {
   -- * keyword: highlights of the keyword
   -- * after: highlights after the keyword (todo text)
   highlight = {
+    override = true, -- allow plugin to override highlights
     multiline = true, -- enable multine todo comments
     multiline_pattern = "^.", -- lua pattern to match the next multiline from the start of the matched keyword
     multiline_context = 10, -- extra lines that will be re-evaluated when changing a line

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -86,7 +86,9 @@ local function add_highlight(buffer, ns, hl, line, from, to)
   --   hl_group = hl,
   --   priority = 500,
   -- })
-  vim.api.nvim_buf_add_highlight(buffer, ns, hl, line, from, to)
+  if Config.options.highlight.override then
+      vim.api.nvim_buf_add_highlight(buffer, ns, hl, line, from, to)
+  end
 end
 
 function M.get_state(buf)


### PR DESCRIPTION
Hey!

I opened this pull request in order to address this issue that I created [here](https://github.com/folke/todo-comments.nvim/issues/212).

But in summary someone had desired the ability to disable highlights and you gave them a way to do so through the pattern key of the highlight table. It works but I found it breaks some features such as the todo quick fix and todo trouble integration which I would definitely want to use.

I added this as a small change that allows keeping your highlight groups as is for todo comments.

If there's formatting changes or another way you'd like this implemented please let me know. I went with what seemed to be the easiest but still sensible route.