### PR TITLE
Remove obsolete icons from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Todo comes with the following defaults:
     TODO = { icon = " ", color = "info" },
     HACK = { icon = " ", color = "warning" },
     WARN = { icon = " ", color = "warning", alt = { "WARNING", "XXX" } },
-    PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
-    NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
+    PERF = { icon = "󱦺 ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
+    NOTE = { icon = "󰍨 ", color = "hint", alt = { "INFO" } },
     TEST = { icon = "⏲ ", color = "test", alt = { "TESTING", "PASSED", "FAILED" } },
   },
   gui_style = {


### PR DESCRIPTION
Just removed some obsolete nerd-font icons from README.md using [nerdfix](https://github.com/loichyan/nerdfix).