### PR TITLE
fix(icons): fix replacements for obsolete nerdfont icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Todo comes with the following defaults:
     TODO = { icon = " ", color = "info" },
     HACK = { icon = " ", color = "warning" },
     WARN = { icon = " ", color = "warning", alt = { "WARNING", "XXX" } },
-    PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
-    NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
+    PERF = { icon = "󰅒 ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
+    NOTE = { icon = "󰍨 ", color = "hint", alt = { "INFO" } },
     TEST = { icon = "⏲ ", color = "test", alt = { "TESTING", "PASSED", "FAILED" } },
   },
   gui_style = {

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -26,8 +26,8 @@ local defaults = {
     TODO = { icon = " ", color = "info" },
     HACK = { icon = " ", color = "warning" },
     WARN = { icon = " ", color = "warning", alt = { "WARNING", "XXX" } },
-    PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
-    NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
+    PERF = { icon = "󰅒 ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
+    NOTE = { icon = "󰍨 ", color = "hint", alt = { "INFO" } },
     TEST = { icon = "⏲ ", color = "test", alt = { "TESTING", "PASSED", "FAILED" } },
   },
   gui_style = {


### PR DESCRIPTION
I'm 98% sure nerdfix didn't replace the icons appropriately in 3bddf1d since they don't match the ones in the Readme. I went ahead and found the new codepoint for each glyph using [the cheatsheet](https://www.nerdfonts.com/cheat-sheet), also updated the Readme to the new codepoints as well.

For reference these are the icons as of now:
![image](https://github.com/folke/todo-comments.nvim/assets/51170833/25b72998-ed81-41cb-b21f-41d3578a6402)

And with this commit:
![image](https://github.com/folke/todo-comments.nvim/assets/51170833/fb012d75-d5f9-445a-b482-eda7291bfa99)


Conflicts with #224 