### PR TITLE
fix: ternary evaluation in setlist for opts.open

### DIFF
--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -106,7 +106,7 @@ end
 
 function M.setlist(opts, use_loclist)
   opts = parse_opts(opts) or {}
-  opts.open = (opts.open ~= nil) and opts.open or true
+  opts.open = (opts.open ~= nil and {opts.open} or {true})[1]
   M.search(function(results)
     if use_loclist then
       vim.fn.setloclist(0, {}, " ", { title = "Todo", id = "$", items = results })


### PR DESCRIPTION
Hi everyone, big thanks for this great plugin.

I've encountered an issue where passing the parameter opts.open to setlist doesn't seem to work. After some investigation, I found that there might be a problem with the evaluation of the ternary expression used here. Due to Lua's short-circuit evaluation, when opts.open = false, it always returns true, causing the parameter passing to become ineffective.