### PR TITLE
fix(highlight): use plain=true for finding offset of keyword

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -47,7 +47,7 @@ function M.match(str, patterns)
     local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
     if #m > 1 and m[2] then
       local kw = m[2]
-      local start = str:find(kw)
+      local start = str:find(kw, 0, true)
       return start, start + #kw, kw
     end
   end


### PR DESCRIPTION
related to https://github.com/folke/todo-comments.nvim/issues/185 / https://github.com/folke/todo-comments.nvim/issues/185#issuecomment-1972101975. The matched keyword shouldn't be re-interpreted as a lua pattern in the `string.find()` call in the highlight module.