### PR TITLE
feat(highlight): allow extended highlighting patterns (#185)

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -46,9 +46,10 @@ function M.match(str, patterns)
   for _, pattern in pairs(patterns) do
     local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
     if #m > 1 and m[2] then
-      local kw = m[2]
-      local start = str:find(kw)
-      return start, start + #kw, kw
+      local match = m[2]
+      local kw = m[3] ~= "" and m[3] or m[2]
+      local start = str:find(match, 1, true)
+      return start, start + #match, kw
     end
   end
 end


### PR DESCRIPTION
Highlight the first capture group pattern, if there is a second (typically nested) capture group, use it for keyword matching.
Allows highlighting `TODO(foo)` using `.*<((KEYWORDS)%(\(.{-1,}\))?):`.

Closes #185, closes #10

This is similar to #180, however that PR's matching behaviour is not backwards compatible with the default highlight pattern used. This PR retains the behaviour that only the first capturing group is highlighted.