### PR TITLE
Return false when the capture is not a comment

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -63,6 +63,7 @@ function M.is_comment(buf, row, col)
         return true
       end
     end
+    return false
   else
     local win = vim.fn.bufwinid(buf)
     return win ~= -1


### PR DESCRIPTION
Prevents jump to next/previous todo comment from hitting context.TODO() in go code.

This problems occurs when using a highlight pattern without a semi-colon (e.g.  pattern = [[.*<(KEYWORDS)>]])  even when comments_only is true.