### PR TITLE
fix(trouble): compatibility with Trouble v3

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -387,7 +387,6 @@ function M.start()
     [[augroup Todo
         autocmd!
         autocmd BufWinEnter,WinNew * lua require("todo-comments.highlight").attach()
-        autocmd BufWritePost * silent! lua require'trouble'.refresh({auto = true, provider = "todo"})
         autocmd WinScrolled * lua require("todo-comments.highlight").highlight_win()
         autocmd ColorScheme * lua vim.defer_fn(require("todo-comments.config").colors, 10)
       augroup end]],


### PR DESCRIPTION
Thank for trouble, which offers us more customization options! Now, Trouble v3 provides an `events` configuration. Therefore, I believe the additional autocmd settings here are unnecessary.

https://github.com/folke/todo-comments.nvim/blob/d58b3767f854963996133dce6113fea62377464b/lua/trouble/sources/todo.lua#L21

To provide more explanation about "unnecessary": 

1) Firstly, the provider parameter no longer works and should be changed to mode = 'todo'. Otherwise, due to filter failure, the autocmd set in todocomment will incorrectly refresh sources that shouldn't be processed.

    https://github.com/folke/trouble.nvim/blob/e32c194558ebeb433ccfd580a34c66770bc102bd/lua/trouble/api.lua#L107

    https://github.com/folke/trouble.nvim/blob/e32c194558ebeb433ccfd580a34c66770bc102bd/lua/trouble/api.lua#L16-L27

    https://github.com/folke/trouble.nvim/blob/e32c194558ebeb433ccfd580a34c66770bc102bd/lua/trouble/view/init.lua#L106-L108

2) Secondly, as explained above, the configuration within `events` already provides the `BufferWritePost` event.

In conclusion, we need to choose the correct version to handle the compatibility issues with the older versions, and I will continue to follow up on this.

Best regards!
