### PR TITLE
fix(highlight): match to the end of length `#matched`

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -49,7 +49,7 @@ function M.match(str, patterns)
       local matched = m[1]
       local kw_only = m[2]
       local start = str:find(matched, 1, true)
-      return start, start + #matched - 1, kw_only
+      return start, start + #matched, kw_only
     end
   end
 end


### PR DESCRIPTION
## What is this PR for?
When using a pattern like `[[(KEYWORDS)\s*(\([^\)]*\)?:)]]` to include the colon character into the capture group, it doesn't take it into consideration for highlighting because currently the range is up to `start + #matched - 1`. This changes the range to `start + #matched`, so it can match correctly until the end of the matched capture group. 

Inspiration was taken from #255, but since #180 was preferred over it, at least make it possible so that it highlights exactly what the users define.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
No
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

