### PR TITLE
perf(highlight): Skip redraw over folded lines

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -101,8 +101,14 @@ function M.redraw(buf, first, last)
   first = math.max(first - Config.options.highlight.multiline_context, 0)
   last = math.min(last + Config.options.highlight.multiline_context, vim.api.nvim_buf_line_count(buf))
   local state = M.get_state(buf)
-  for i = first, last do
-    state.dirty[i] = true
+  while first <= last do
+    -- skip over lines that are hidden under a fold
+    if vim.fn.foldclosed(first) == -1 then
+      state.dirty[first] = true
+    else
+      first = vim.fn.foldclosedend(first)
+    end
+    first = first + 1
   end
   if not M.timer then
     M.timer = vim.defer_fn(M.update, Config.options.highlight.throttle)


### PR DESCRIPTION


## Description

Currently on a window update such as `WinScroll` highlight_win is looping through every line from from `w0` to `w$` to update the highlights. On large files with very large folded regions these two lines can be very far apart and highlighting every single line can be costly even though they are not in view. This update adds a check to skip over any lines hidden in a fold.

## Related Issue(s)

Fixes: #285

## Screenshots

Looks a little choppy due to the video quality but scrolling a lot smoother, compare to video from original issue:
![Screen Recording 2024-07-26 at 1 56 46 PM](https://github.com/user-attachments/assets/3ceea4c2-b906-4767-953a-edb2c840f465)




