### PR TITLE
feat(fzf): add fzf-lua support in Readme & add TodoFzfLua command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - configurable **signs**
 - open todos in a **quickfix** list
 - open todos in [Trouble](https://github.com/folke/trouble.nvim)
-- search todos with [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+- search todos with [Telescope](https://github.com/nvim-telescope/telescope.nvim) & [FzfLua](https://github.com/ibhagwan/fzf-lua)
 
 ## ⚡️ Requirements
 
@@ -22,6 +22,7 @@
   + [ripgrep](https://github.com/BurntSushi/ripgrep) and [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) are used for searching.
   + [Trouble](https://github.com/folke/trouble.nvim)
   + [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+  + [FzfLua](https://github.com/ibhagwan/fzf-lua)
 
 ## 📦 Installation
 
@@ -183,6 +184,9 @@ Use Trouble's filtering: `Trouble todo filter = {tag = {TODO,FIX,FIXME}}`
 Search through all project todos with Telescope
 
 ![image](https://user-images.githubusercontent.com/292349/118135371-ccb91200-b3b7-11eb-9002-66af3b683cf0.png)
+
+> [!Note]
+> The same can be done with `:TodoFzfLua`
 
 <!-- markdownlint-disable-file MD033 -->
 <!-- markdownlint-configure-file { "MD013": { "line_length": 120 } } -->

--- a/plugin/todo.vim
+++ b/plugin/todo.vim
@@ -1,4 +1,5 @@
 command! -nargs=* TodoQuickFix lua require("todo-comments.search").setqflist(<q-args>)
 command! -nargs=* TodoLocList lua require("todo-comments.search").setloclist(<q-args>)
 command! -nargs=* TodoTelescope Telescope todo-comments todo <args>
+command! -nargs=* TodoFzfLua lua require("todo-comments.fzf").todo() <args>
 command! -nargs=* TodoTrouble Trouble todo <args>


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This plugin has support `fzf-lua` ( an alternative to `Telescope` ) in lua/fzf.lua. But nowhere in the `README` it is said that there's `fzf-lua` support, so i added it explicitly in the `README`. There's also no commands to call the function so i added the `TodoFzfLua` command