### PR TITLE
fix(config): select `fg` by maximizing contrast rather than check if a color is dark

### DIFF
--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -182,7 +182,7 @@ function M.colors()
     if not hex then
       error("Todo: no color for " .. kw)
     end
-    local fg = Util.is_dark(hex) and fg_light or fg_dark
+    local fg = Util.select_fg(hex, fg_light, fg_dark)
 
     vim.cmd("hi def TodoBg" .. kw .. " guibg=" .. hex .. " guifg=" .. fg .. " gui=" .. bg_gui)
     vim.cmd("hi def TodoFg" .. kw .. " guibg=NONE guifg=" .. hex .. " gui=" .. fg_gui)

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -147,10 +147,18 @@ end
 
 function M.colors()
   local normal = Util.get_hl("Normal")
-  local fg_dark = Util.is_dark(normal.foreground or "#ffffff") and normal.foreground or normal.background
-  local fg_light = Util.is_dark(normal.foreground or "#ffffff") and normal.background or normal.foreground
-  fg_dark = fg_dark or "#000000"
-  fg_light = fg_light or "#ffffff"
+  local normal_fg = normal.foreground
+  local normal_bg = normal.background
+  local default_dark = "#000000"
+  local default_light = "#FFFFFF"
+  if not normal_fg and not normal_bg then
+    normal_fg = default_light
+    normal_bg = default_dark
+  elseif not normal_fg then
+    normal_fg = Util.maximize_contrast(normal_bg, default_dark, default_light)
+  elseif not normal_bg then
+    normal_bg = Util.maximize_contrast(normal_fg, default_dark, default_light)
+  end
   local fg_gui = M.options.gui_style.fg
   local bg_gui = M.options.gui_style.bg
 
@@ -182,7 +190,7 @@ function M.colors()
     if not hex then
       error("Todo: no color for " .. kw)
     end
-    local fg = Util.select_fg(hex, fg_light, fg_dark)
+    local fg = Util.maximize_contrast(hex, normal_fg, normal_bg)
 
     vim.cmd("hi def TodoBg" .. kw .. " guibg=" .. hex .. " guifg=" .. fg .. " gui=" .. bg_gui)
     vim.cmd("hi def TodoFg" .. kw .. " guibg=NONE guifg=" .. hex .. " gui=" .. fg_gui)

--- a/lua/todo-comments/util.lua
+++ b/lua/todo-comments/util.lua
@@ -14,22 +14,38 @@ function M.get_hl(name)
   return hl
 end
 
-function M.hex2rgb(hex)
+local function rgb_to_linear(c)
+  c = c / 255
+  return c <= 0.04045 and c / 12.92 or ((c + 0.055) / 1.055) ^ 2.4
+end
+
+local function relative_luminance(color)
+  return 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b
+end
+
+function M.hex2linear_srgb(hex)
   hex = hex:gsub("#", "")
-  return tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)), tonumber("0x" .. hex:sub(5, 6))
+  return {
+    r = rgb_to_linear(tonumber("0x" .. hex:sub(1, 2))),
+    g = rgb_to_linear(tonumber("0x" .. hex:sub(3, 4))),
+    b = rgb_to_linear(tonumber("0x" .. hex:sub(5, 6))),
+  }
 end
 
-function M.rgb2hex(r, g, b)
-  return string.format("#%02x%02x%02x", r, g, b)
-end
+function M.contrast_ratio(c1, c2)
+  local lum1 = relative_luminance(c1)
+  local lum2 = relative_luminance(c2)
 
-function M.color_distance(r1, g1, b1, r2, g2, b2)
-  return math.sqrt((r1 - r2) ^ 2 + (g1 - g2) ^ 2 + (b1 - b2) ^ 2)
+  if lum1 < lum2 then
+    lum1, lum2 = lum2, lum1
+  end
+
+  return (lum1 + 0.05) / (lum2 + 0.05)
 end
 
 function M.maximize_contrast(base, fg1, fg2)
-  local r, g, b = M.hex2rgb(base)
-  return M.color_distance(r, g, b, M.hex2rgb(fg1)) > M.color_distance(r, g, b, M.hex2rgb(fg2)) and fg1 or fg2
+  base = M.hex2linear_srgb(base)
+  return M.contrast_ratio(base, M.hex2linear_srgb(fg1)) > M.contrast_ratio(base, M.hex2linear_srgb(fg2)) and fg1 or fg2
 end
 
 function M.warn(msg)

--- a/lua/todo-comments/util.lua
+++ b/lua/todo-comments/util.lua
@@ -23,17 +23,11 @@ function M.rgb2hex(r, g, b)
   return string.format("#%02x%02x%02x", r, g, b)
 end
 
-function M.is_dark(hex)
-  local r, g, b = M.hex2rgb(hex)
-  local lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-  return lum <= 0.5
-end
-
 function M.color_distance(r1, g1, b1, r2, g2, b2)
   return math.sqrt((r1 - r2) ^ 2 + (g1 - g2) ^ 2 + (b1 - b2) ^ 2)
 end
 
-function M.select_fg(base, fg1, fg2)
+function M.maximize_contrast(base, fg1, fg2)
   local r, g, b = M.hex2rgb(base)
   return M.color_distance(r, g, b, M.hex2rgb(fg1)) > M.color_distance(r, g, b, M.hex2rgb(fg2)) and fg1 or fg2
 end

--- a/lua/todo-comments/util.lua
+++ b/lua/todo-comments/util.lua
@@ -29,6 +29,15 @@ function M.is_dark(hex)
   return lum <= 0.5
 end
 
+function M.color_distance(r1, g1, b1, r2, g2, b2)
+  return math.sqrt((r1 - r2) ^ 2 + (g1 - g2) ^ 2 + (b1 - b2) ^ 2)
+end
+
+function M.select_fg(base, fg1, fg2)
+  local r, g, b = M.hex2rgb(base)
+  return M.color_distance(r, g, b, M.hex2rgb(fg1)) > M.color_distance(r, g, b, M.hex2rgb(fg2)) and fg1 or fg2
+end
+
 function M.warn(msg)
   vim.notify(msg, vim.log.levels.WARN, { title = "TodoComments" })
 end


### PR DESCRIPTION
## Description

This PR changes a bit of of the internal logic used for calculating the foreground for a given background color. Currently it uses an algorithm to guess if the dark or light color is better. This rather uses the contrast ratio metric as described by the WCAG to maximize visual difference between the foreground and background.

Let me know what you think of this solution! Thanks so much for a great plugin!

EDIT: moved from Euclidian distance in the RGB space to the official contrast definition by the WCAG for identifying the contrast between foreground and background colors which accounts for difference in color perception to the human eye. (https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)

## Related Issue(s)

Fixes #315 

## Screenshots

Here is a color that resolves incorrectly without this PR:

![image](https://github.com/user-attachments/assets/aba6bdaf-bd69-4f16-90bf-d8b7d4f130a1)

Here is the same color with this PR:

![image](https://github.com/user-attachments/assets/db7372a1-cba8-4f0d-bd00-0c0931e15dad)
