### PR TITLE
feat: add option to wraparound when jumping to comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ vim.keymap.set("n", "]t", function()
   require("todo-comments").jump_next({keywords = { "ERROR", "WARNING" }})
 end, { desc = "Next error/warning todo comment" })
 
+-- If you want to wrap around to the first/last todo comment when you reach the end/beginning of the buffer
+
+vim.keymap.set("n", "]t", function()
+  require("todo-comments").jump_next({wraparound = true})
+end, { desc = "Next todo comment" })
+
+vim.keymap.set("n", "[t", function()
+  require("todo-comments").jump_prev({wraparound = true})
+end, { desc = "Previous todo comment" })
 ```
 
 ## 🚀 Usage

--- a/lua/todo-comments/jump.lua
+++ b/lua/todo-comments/jump.lua
@@ -41,7 +41,38 @@ local function jump(up, opts)
       return
     end
   end
-  util.warn("No more todo comments to jump to")
+
+  if opts.wraparound then
+    if up then
+      from = vim.api.nvim_buf_line_count(buf)
+      to = pos[1] + 1
+    else
+      from = 1
+      to = pos[1] - 1
+    end
+    for l = from, to, up and -1 or 1 do
+      local line = vim.api.nvim_buf_get_lines(buf, l - 1, l, false)[1] or ""
+      local ok, start, _, kw = pcall(highlight.match, line)
+
+      if ok and start then
+        if config.options.highlight.comments_only and highlight.is_comment(buf, l - 1, start) == false then
+          kw = nil
+        end
+      end
+
+      if kw and #opts.keywords > 0 and not vim.tbl_contains(opts.keywords, kw) then
+        kw = nil
+      end
+
+      if kw then
+        vim.api.nvim_win_set_cursor(win, { l, start - 1 })
+        return
+      end
+    end
+    util.warn("No todo comments in this buffer")
+  else
+    util.warn("No more todo comments to jump to")
+  end
 end
 
 function M.next(opts)


### PR DESCRIPTION
## Description

Adds the option to wraparound to the start/end of the buffer when jumping to comments instead of ending the search. Useful for users that might prefer this behavior.
