### PR TITLE
Allow showing TodoQuickFix list in sorted order

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Todo comes with the following defaults:
     -- don't replace the (KEYWORDS) placeholder
     pattern = [[\b(KEYWORDS):]], -- ripgrep regex
     -- pattern = [[\b(KEYWORDS)\b]], -- match without the extra colon. You'll likely get false positives
+    sorted_quickfix = false,
   },
 }
 

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -77,6 +77,7 @@ local defaults = {
     -- don't replace the (KEYWORDS) placeholder
     pattern = [[\b(KEYWORDS):]], -- ripgrep regex
     -- pattern = [[\b(KEYWORDS)\b]], -- match without the extra colon. You'll likely get false positives
+    sorted_quickfix = false,
   },
 }
 

--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -39,6 +39,13 @@ function M.process(lines)
       end
     end
   end
+
+  if Config.options.search.sorted_quickfix == true then
+    table.sort(results, function(a, b)
+      return a.line <= b.line
+    end)
+  end
+
   return results
 end
 

--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -42,7 +42,9 @@ function M.process(lines)
 
   if Config.options.search.sorted_quickfix == true then
     table.sort(results, function(a, b)
-      return a.line <= b.line
+      local first = a.line:match(":(.*)")
+      local second = b.line:match(":(.*)")
+      return first <= second
     end)
   end
 


### PR DESCRIPTION
This is specially usefull when documenting  observations as comments while working on a project in order to save the context for future.

A keyword like PIN can be defined, with a search regexp as [[PIN \d{2}]] and the comments can be numbered as # PIN: 00, # PIN: 01.. Then using the TodoQuickFix command will show all the pins in the sorted order, which makes it really easy to go over the past observations etc.

fixes #330