### PR TITLE
feat: customise default foreground colour

### DIFF
--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -64,6 +64,10 @@ local defaults = {
     default = { "Identifier", "#7C3AED" },
     test = { "Identifier", "#FF00FF" },
   },
+  default_fg = {
+    dark = "#000000",
+    light = "#FFFFFF",
+  },
   search = {
     command = "rg",
     args = {
@@ -149,8 +153,8 @@ function M.colors()
   local normal = Util.get_hl("Normal")
   local normal_fg = normal.foreground
   local normal_bg = normal.background
-  local default_dark = "#000000"
-  local default_light = "#FFFFFF"
+  local default_dark = M.options.default_fg.dark
+  local default_light = M.options.default_fg.light
   if not normal_fg and not normal_bg then
     normal_fg = default_light
     normal_bg = default_dark


### PR DESCRIPTION
## Description

In my own fork, I'm forcing the foreground colour manually because I like it white regardless of the contrast or `Normal` hl. Currently, `default_dark` and `default_white` are hardcoded in `M.colors`, I think it'd be better if they could be customised from the config.

