### PR TITLE
feat(TodoTelescope): new options to change how TodoTelescope displays file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,21 @@ Use Trouble's filtering: `Trouble todo filter = {tag = {TODO,FIX,FIXME}}`
 
 Search through all project todos with Telescope
 
+This command accepts the following optional arguments:
+
+- `path` - Change how paths are displayed in the results.
+
+```vim
+:TodoTelescope path=false
+:TodoTelescope path=name
+```
+
+- `position` - Disable the line and column numbers.
+
+```vim
+:TodoTelescope position=false
+```
+
 ![image](https://user-images.githubusercontent.com/292349/118135371-ccb91200-b3b7-11eb-9002-66af3b683cf0.png)
 
 > [!Note]
@@ -191,3 +206,4 @@ Search through all project todos with Telescope
 <!-- markdownlint-disable-file MD033 -->
 <!-- markdownlint-configure-file { "MD013": { "line_length": 120 } } -->
 <!-- markdownlint-configure-file { "MD004": { "style": "sublist" } } -->
+

--- a/lua/telescope/_extensions/todo-comments.lua
+++ b/lua/telescope/_extensions/todo-comments.lua
@@ -21,6 +21,17 @@ local function keywords_filter(opts_keywords)
   end, all_keywords)
 end
 
+local function format_display(entry, opts)
+  if opts.path == false then return "" end
+  local filename = opts.path == "name" and vim.fn.fnamemodify(entry.filename, ":t") or entry.filename
+
+  if opts.position == false then
+    return string.format("%s ", filename)
+  else
+    return string.format("%s:%s:%s ", filename, entry.lnum, entry.col)
+  end
+end
+
 local function todo(opts)
   opts = opts or {}
   opts.vimgrep_arguments = { Config.options.search.command }
@@ -33,7 +44,8 @@ local function todo(opts)
   opts.entry_maker = function(line)
     local ret = entry_maker(line)
     ret.display = function(entry)
-      local display = string.format("%s:%s:%s ", entry.filename, entry.lnum, entry.col)
+      local display = format_display(entry, opts)
+
       local text = entry.text
       local start, finish, kw = Highlight.match(text)
 


### PR DESCRIPTION
## Description

When using `:TodoTelescope` in large projects with lots of nested folders, sometimes all you can see is file paths. I added a few options to help with this.

`path=false` to hide paths completely
`path=name` to show only the name of the file
`position=false` to hide the line/column numbers

## Examples

`:TodoTelescope` (default)
![Screenshot 2025-06-03 212209](https://github.com/user-attachments/assets/fe77ab88-0739-482b-9c84-a4f4a57cf3ad)

`:TodoTelescope path=name position=false`
![Screenshot 2025-06-03 212240](https://github.com/user-attachments/assets/b2dc2811-83e1-4646-991e-db2cfefd4dc5)

`:TodoTelescope path=false`
![Screenshot 2025-06-03 212306](https://github.com/user-attachments/assets/4a297c37-8eb6-49c8-a64b-c9017d17f6be)


