### PR TITLE
fix(highlight): only update visible parts

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -334,6 +334,10 @@ function M.attach(win)
           return true
         end
 
+        -- Only update the visible part
+        -- The invisible part will be updated when 'WinScrolled'
+        first = math.max(first, vim.fn.line("w0", win) - 1)
+        last_new = math.min(last_new, vim.fn.line("w$", win))
         M.redraw(buf, first, last_new)
       end,
       on_detach = function()


### PR DESCRIPTION
## Description

When paste a large content into a buffer (600w lines), this plugin will cause nvim frozen.

This pr solves this problem by only updating the visible lines of a buffer.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

