### PR TITLE
docs(docs): fix typo "multine" → "multiline" in readme, help docs, and config comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Todo comes with the following defaults:
   -- * keyword: highlights of the keyword
   -- * after: highlights after the keyword (todo text)
   highlight = {
-    multiline = true, -- enable multine todo comments
+    multiline = true, -- enable multiline todo comments
     multiline_pattern = "^.", -- lua pattern to match the next multiline from the start of the matched keyword
     multiline_context = 10, -- extra lines that will be re-evaluated when changing a line
     before = "", -- "fg" or "bg" or empty

--- a/doc/todo-comments.nvim.txt
+++ b/doc/todo-comments.nvim.txt
@@ -92,7 +92,7 @@ Todo comes with the following defaults:
       -- * keyword: highlights of the keyword
       -- * after: highlights after the keyword (todo text)
       highlight = {
-        multiline = true, -- enable multine todo comments
+        multiline = true, -- enable multiline todo comments
         multiline_pattern = "^.", -- lua pattern to match the next multiline from the start of the matched keyword
         multiline_context = 10, -- extra lines that will be re-evaluated when changing a line
         before = "", -- "fg" or "bg" or empty

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -40,7 +40,7 @@ local defaults = {
   -- * keyword: highlights of the keyword
   -- * after: highlights after the keyword (todo text)
   highlight = {
-    multiline = true, -- enable multine todo comments
+    multiline = true, -- enable multiline todo comments
     multiline_pattern = "^.", -- lua pattern to match the next multiline from the start of the matched keyword
     multiline_context = 10, -- extra lines that will be re-evaluated when changing a line
     before = "", -- "fg" or "bg" or empty


### PR DESCRIPTION
Not really anything more than a simple typo. I dont really know if the name is intentional, but "multiline" makes more sense than "multine" nonetheless.