### PR TITLE
fix(highlight): set extmark out of line range

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -91,6 +91,10 @@ end
 ---@param from number
 ---@param to number
 local function add_highlight(buf, ns, hl, line, from, to)
+  local line_length = vim.api.nvim_buf_get_lines(buf, line, line + 1, false)[1]:len()
+  if to > line_length then
+    to = line_length
+  end
   vim.api.nvim_buf_set_extmark(buf, ns, line, from, {
     end_col = to,
     hl_group = hl,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

In the following Erlang code:

```erlang
myfun() ->
    %% @todo
    %% Some comment
    ok.
```

The `highlight` function calls `add_hightlight` with the `finish + 1` as the `to` parameter, which is out of the line length.

https://github.com/folke/todo-comments.nvim/blob/main/lua/todo-comments/highlight.lua#L244-L248



## Screenshots

<img width="977" height="278" alt="image" src="https://github.com/user-attachments/assets/a6c74e97-8d27-41c9-a74c-50c0b95cabf0" />

After patched:

<img width="672" height="206" alt="image" src="https://github.com/user-attachments/assets/689e7c62-3057-46f9-9e7c-4e7c7adee4cf" />
