### PR TITLE
fix(TodoFzfLua):  handle "keywords=..." and "cwd=..." args

### DIFF
--- a/lua/todo-comments/fzf.lua
+++ b/lua/todo-comments/fzf.lua
@@ -15,8 +15,20 @@ local function keywords_filter(filter)
   end, all)
 end
 
----@param opts? {keywords: string[]}
+---@param opts? {keywords: string[], cwd: string, user_args: string}
 function M.todo(opts)
+  --- `opts.user_args` being set implies that the call was made through the `TodoFzfLua` user command defined in "plugin/todo.vim". In that case, we must parse the arguments accordingly.
+  if opts and opts.user_args then
+    for _, arg_str in ipairs(vim.split(opts.user_args, " ")) do
+      local k, v = table.unpack(vim.split(arg_str, "="))
+      if k == "keywords" then
+        opts.keywords = vim.split(v, ",")
+      elseif k == "cwd" then
+        opts.cwd = v
+      end
+    end
+    opts.user_args = nil
+  end
   opts = vim.tbl_extend("force", {
     no_esc = true,
     multiline = true,

--- a/plugin/todo.vim
+++ b/plugin/todo.vim
@@ -1,5 +1,6 @@
 command! -nargs=* TodoQuickFix lua require("todo-comments.search").setqflist(<q-args>)
 command! -nargs=* TodoLocList lua require("todo-comments.search").setloclist(<q-args>)
 command! -nargs=* TodoTelescope Telescope todo-comments todo <args>
-command! -nargs=* TodoFzfLua lua require("todo-comments.fzf").todo() <args>
+" FIXME: Update TodoFzfLua here?
+command! -nargs=* TodoFzfLua lua require("todo-comments.fzf").todo({user_args = <q-args>})
 command! -nargs=* TodoTrouble Trouble todo <args>


### PR DESCRIPTION
[README.md](https://github.com/folke/todo-comments.nvim/blob/31e3c38ce9b29781e4422fc0322eb0a21f4e8668/README.md?plain=1#L189) points out that the "keywords=..." and "cwd=..." args should work with `TodoFzfLua` as they do with `TodoTelescope`. However, when calling `TodoFzfLua`, additional arguments were ignored.

Handle arguments passed to `TodoFzfLua` by introducing an additional `user_args` parameter in the table received by the `todo()` function in "todo-comments/fzf.lua", which allows the `todo()` function to parse and handle the arguments accordingly.

Passing the arguments through the lua API is also supported via `:lua require("todo-comments.fzf").todo({ keywords = { "TODO", "FIXME" }, cwd = "foo/bar"})`