### PR TITLE
fix(highlight): wrap extmark call in pcall to handle race conditions

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -91,7 +91,8 @@ end
 ---@param from number
 ---@param to number
 local function add_highlight(buf, ns, hl, line, from, to)
-  vim.api.nvim_buf_set_extmark(buf, ns, line, from, {
+  -- Wrap in pcall to handle race conditions during buffer modifications (e.g., abbreviation expansion)
+  pcall(vim.api.nvim_buf_set_extmark, buf, ns, line, from, {
     end_col = to,
     hl_group = hl,
     priority = 500,


### PR DESCRIPTION
Prevents errors during buffer modifications such as abbreviation expansion by safely handling potential failures in `nvim_buf_set_extmark`.

## Description

This PR fixes a race condition that can occur during buffer modifications, particularly when abbreviations are expanded. The `nvim_buf_set_extmark` API call can fail if the buffer is modified between the time the highlighting is calculated and when the `extmark` is applied.

By wrapping the `nvim_buf_set_extmark` call in `pcall`, we gracefully handle these transient failures without throwing errors to the user. This is particularly important for maintaining a smooth editing experience when using features like abbreviation expansion, which can modify buffer contents in ways that race with the highlighting system.

The change is minimal and defensive - if the `extmark` fails to be set due to a race condition, we simply skip it rather than crashing. The highlighting will be recalculated and applied on the next update cycle.

## Related Issue(s)

Not applicable - this is a bug fix that prevents errors during normal editing operations. The visual behavior remains unchanged, but errors that previously occurred during abbreviation expansion and similar buffer modifications are now prevented.
