### PR TITLE
feat(padding): implement keyword padding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 - **highlight** your todo comments in different styles
 - optionally only highlights todos in comments using **TreeSitter**
+- configurable **padding** around keywords with virtual text
 - configurable **signs**
 - open todos in a **quickfix** list
 - open todos in [Trouble](https://github.com/folke/trouble.nvim)
@@ -85,6 +86,13 @@ Todo comes with the following defaults:
     comments_only = true, -- uses treesitter to match keywords in comments only
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
+    padding = { -- padding characters around keywords
+      enabled = false, -- enable padding feature
+      left = "", -- left padding character(s)
+      right = "", -- right padding character(s)
+      hide_colon = false, -- hide the colon after the keyword
+      hide_on_cursor = true, -- hide padding when cursor is on the line
+    },
   },
   -- list of named colors where we try to extract the guifg from the
   -- list of highlight groups or use the hex color if hl not found as a fallback
@@ -113,6 +121,92 @@ Todo comes with the following defaults:
 }
 
 ```
+
+### Padding
+
+You can add virtual padding around keywords, creating a more distinctive appearance for your TODO comments.
+
+#### Basic Configuration
+
+```lua
+require("todo-comments").setup({
+  highlight = {
+    padding = {
+      enabled = true,
+      left = "",
+      right = "",
+      hide_colon = true,
+      hide_on_cursor = true,
+    },
+  },
+})
+
+-- Required for hide_colon to work
+vim.opt.conceallevel = 2
+```
+
+This configuration will display `TODO` when the cursor is away from the line, and `TODO:` when the cursor is on the line.
+
+#### Options
+
+- `enabled` - Enable or disable the padding feature (default: `false`)
+- `left` - Character(s) to display before the keyword (default: `""`)
+- `right` - Character(s) to display after the keyword (default: `""`)
+- `hide_colon` - Conceal the colon after the keyword (default: `false`). Requires `vim.opt.conceallevel >= 1`
+- `hide_on_cursor` - Hide padding when the cursor is on the line (default: `true`)
+
+**Note:** The `hide_colon` and `hide_on_cursor` options work independently. When `hide_on_cursor` is `false`, the padding and colon concealing remain active even when the cursor is on the line.
+
+#### Per-Keyword Padding
+
+You can customize padding for individual keywords:
+
+```lua
+require("todo-comments").setup({
+  highlight = {
+    padding = {
+      enabled = true,
+      left = "",
+      right = "",
+      hide_colon = true,
+      hide_on_cursor = true,
+    },
+  },
+  keywords = {
+    WARN = {
+      padding = {
+        left = " ",
+        right = " ",
+      },
+    },
+    FIX = {
+      padding = {
+        left = " ",
+        right = "",
+        hide_colon = false,
+      },
+    },
+    NOTE = {
+      padding = {
+        right = " ",
+      },
+    },
+    BUG = {
+      padding = {
+        left = "",
+        right = "",
+      },
+    }
+  },
+})
+```
+
+In this example:
+- `WARN` keywords will be surrounded by ` ` and ` `.
+- `FIX` keywords will be surrounded by `` and ``, with the colon always visible
+- `NOTE` keywords will inherit the default left padding but be padded with ` ` on the right.
+- `BUG` keywords will have no padding.
+- Other keywords will use the default padding configuration
 
 ### Jumping
 

--- a/doc/todo-comments.nvim.txt
+++ b/doc/todo-comments.nvim.txt
@@ -8,6 +8,7 @@ Table of Contents                       *todo-comments.nvim-table-of-contents*
   - Requirements               |todo-comments.nvim-todo-comments-requirements|
   - Installation               |todo-comments.nvim-todo-comments-installation|
   - Configuration             |todo-comments.nvim-todo-comments-configuration|
+  - Padding                                       |todo-comments.nvim-padding|
   - Usage                             |todo-comments.nvim-todo-comments-usage|
 2. Links                                            |todo-comments.nvim-links|
 
@@ -22,6 +23,7 @@ FEATURES                           *todo-comments.nvim-todo-comments-features*
 
 - **highlight** your todo comments in different styles
 - optionally only highlights todos in comments using **TreeSitter**
+- **padding** - configurable padding around keywords with virtual text
 - configurable **signs**
 - open todos in a **quickfix** list
 - open todos in Trouble <https://github.com/folke/trouble.nvim>
@@ -102,6 +104,13 @@ Todo comes with the following defaults:
         comments_only = true, -- uses treesitter to match keywords in comments only
         max_line_len = 400, -- ignore lines longer than this
         exclude = {}, -- list of file types to exclude highlighting
+        padding = { -- padding characters around keywords
+          enabled = false, -- enable padding feature
+          left = "", -- left padding character(s)
+          right = "", -- right padding character(s)
+          hide_colon = false, -- hide the colon after the keyword
+          hide_on_cursor = true, -- hide padding when cursor is on the line
+        },
       },
       -- list of named colors where we try to extract the guifg from the
       -- list of highlight groups or use the hex color if hl not found as a fallback
@@ -129,6 +138,105 @@ Todo comes with the following defaults:
       },
     }
 <
+
+
+PADDING ~
+                                             *todo-comments.nvim-padding*
+
+You can add virtual padding around keywords, creating a more distinctive
+appearance for your TODO comments.
+
+
+BASIC CONFIGURATION ~
+
+>lua
+    require("todo-comments").setup({
+      highlight = {
+        padding = {
+          enabled = true,
+          left = "",
+          right = "",
+          hide_colon = true,
+          hide_on_cursor = true,
+        },
+      },
+    })
+
+    -- Required for hide_colon to work
+    vim.opt.conceallevel = 2
+<
+
+This configuration will display `TODO` when the cursor is away from the
+line, and `TODO:` when the cursor is on the line.
+
+
+OPTIONS ~
+
+- `enabled` - Enable or disable the padding feature (default: `false`)
+- `left` - Character(s) to display before the keyword (default: `""`)
+- `right` - Character(s) to display after the keyword (default: `""`)
+- `hide_colon` - Conceal the colon after the keyword (default: `false`).
+  Requires `vim.opt.conceallevel >= 1`
+- `hide_on_cursor` - Hide padding when the cursor is on the line
+  (default: `true`)
+
+Note: The `hide_colon` and `hide_on_cursor` options work independently. When
+`hide_on_cursor` is `false`, the padding and colon concealing remain active
+even when the cursor is on the line.
+
+
+PER-KEYWORD PADDING ~
+
+You can customize padding for individual keywords:
+
+>lua
+    require("todo-comments").setup({
+      highlight = {
+        padding = {
+          enabled = true,
+          left = "",
+          right = "",
+          hide_colon = true,
+          hide_on_cursor = true,
+        },
+      },
+      keywords = {
+        WARN = {
+          padding = {
+            left = " ",
+            right = " ",
+          },
+        },
+        FIX = {
+          padding = {
+            left = " ",
+            right = "",
+            hide_colon = false,
+          },
+        },
+        NOTE = {
+          padding = {
+            right = " ",
+          },
+        },
+        BUG = {
+          padding = {
+            left = "",
+            right = "",
+          },
+        }
+      },
+    })
+<
+
+In this example:
+- `WARN` keywords will be surrounded by ` ` and ` `.
+- `FIX` keywords will be surrounded by `` and ``, with the colon always 
+  visible
+- `NOTE` keywords will inherit the default left padding but be padded with 
+  ` ` on the right.
+- `BUG` keywords will have no padding.
+- Other keywords will use the default padding configuration
 
 
 JUMPING ~

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -53,6 +53,13 @@ local defaults = {
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
     throttle = 200,
+    padding = { -- padding characters around keywords
+      enabled = false, -- enable padding feature
+      left = "", -- left padding character(s)
+      right = "", -- right padding character(s)
+      hide_colon = false, -- hide the colon after the keyword
+      hide_on_cursor = true, -- hide padding when cursor is on the line
+    },
   },
   -- list of named colors where we try to extract the guifg from the
   -- list of hilight groups or use the hex color if hl not found as a fallback

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -2,6 +2,7 @@
 -- TODO: foobar
 -- dddddd
 local Config = require("todo-comments.config")
+local Padding = require("todo-comments.padding")
 
 ---@module 'uv'
 
@@ -9,6 +10,7 @@ local M = {}
 M.enabled = false
 M.bufs = {} ---@type table<number, boolean>
 M.wins = {} ---@type table<number, boolean>
+M.cursor_lines = {} ---@type table<number, number>
 
 -- PERF: fully optimised
 -- FIX: ddddddasdasdasdasdasda
@@ -172,6 +174,17 @@ function M.highlight(buf, first, last, _event)
   end
 
   vim.api.nvim_buf_clear_namespace(buf, Config.ns, first, last + 1)
+  Padding.clear(buf, first, last)
+
+  -- Get cursor position for this buffer
+  local cursor_line = nil
+  local wins = vim.fn.win_findbuf(buf)
+  if #wins > 0 then
+    local ok, cursor = pcall(vim.api.nvim_win_get_cursor, wins[1])
+    if ok then
+      cursor_line = cursor[1] - 1
+    end
+  end
 
   -- clear signs
   for _, sign in pairs(vim.fn.sign_getplaced(buf, { group = "todo-signs" })[1].signs) do
@@ -251,6 +264,9 @@ function M.highlight(buf, first, last, _event)
         elseif hl.keyword == "fg" then
           add_highlight(buf, Config.ns, hl_fg, lnum, start, finish)
         end
+
+        -- Add padding around keyword
+        Padding.add(buf, lnum, kw, start, finish, line, lnum == cursor_line)
       end
 
       -- after highlights
@@ -360,6 +376,7 @@ function M.attach(win, force)
       on_detach = function()
         M.state[buf] = nil
         M.bufs[buf] = nil
+        M.cursor_lines[buf] = nil
       end,
     })
 
@@ -398,9 +415,11 @@ function M.stop()
   for buf, _ in pairs(M.bufs) do
     if vim.api.nvim_buf_is_valid(buf) then
       pcall(vim.api.nvim_buf_clear_namespace, buf, Config.ns, 0, -1)
+      pcall(vim.api.nvim_buf_clear_namespace, buf, Padding.ns, 0, -1)
     end
   end
   M.bufs = {}
+  M.cursor_lines = {}
 end
 
 function M.start()
@@ -426,6 +445,34 @@ function M.start()
     group = group,
     callback = function(ev)
       vim.defer_fn(require("todo-comments.config").colors, 10)
+    end,
+  })
+  -- Cursor movement tracking for hide_on_cursor feature
+  vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+    group = group,
+    callback = function(ev)
+      if not Config.options.highlight.padding.enabled or not Config.options.highlight.padding.hide_on_cursor then
+        return
+      end
+
+      local buf = ev.buf
+      local ok, cursor = pcall(vim.api.nvim_win_get_cursor, 0)
+      if not ok then
+        return
+      end
+      local cursor_line = cursor[1] - 1
+      local prev_line = M.cursor_lines[buf]
+
+      if prev_line and prev_line ~= cursor_line then
+        -- Update previous line (add padding back)
+        M.highlight(buf, prev_line, prev_line)
+      end
+      if cursor_line then
+        -- Update current line (remove padding)
+        M.highlight(buf, cursor_line, cursor_line)
+      end
+
+      M.cursor_lines[buf] = cursor_line
     end,
   })
 

--- a/lua/todo-comments/padding.lua
+++ b/lua/todo-comments/padding.lua
@@ -1,0 +1,95 @@
+local Config = require("todo-comments.config")
+
+---@class TodoPadding
+local M = {}
+
+-- Create dedicated namespace for padding extmarks
+M.ns = vim.api.nvim_create_namespace("todo-comments-padding")
+
+---Add padding extmarks around a keyword
+---@param buf number buffer number
+---@param lnum number 0-indexed line number
+---@param kw string keyword name (e.g., "TODO", "FIX")
+---@param kw_start number 0-indexed start position of keyword
+---@param kw_end number 0-indexed end position of keyword (exclusive)
+---@param line string the full line text
+---@param on_cursor_line boolean whether the cursor is on this line
+function M.add(buf, lnum, kw, kw_start, kw_end, line, on_cursor_line)
+  if not Config.options.highlight.padding.enabled then
+    return
+  end
+
+  local opts = Config.options.keywords[kw]
+  if not opts then
+    return
+  end
+
+  -- Get padding characters (per-keyword override or default)
+  local padding_config = opts.padding or {}
+  local left = padding_config.left or Config.options.highlight.padding.left
+  local right = padding_config.right or Config.options.highlight.padding.right
+
+  -- Determine if we should hide padding characters on cursor line
+  local should_hide_padding = on_cursor_line and Config.options.highlight.padding.hide_on_cursor
+
+  -- Add padding characters (unless hidden on cursor line)
+  if not should_hide_padding and (left ~= "" or right ~= "") then
+    local hl_fg = "TodoFg" .. kw
+    local hl_bg = "TodoBg" .. kw
+
+    -- Add background highlight to keyword itself
+    vim.api.nvim_buf_set_extmark(buf, M.ns, lnum, kw_start, {
+      end_col = kw_end,
+      hl_group = hl_bg,
+      priority = 500,
+    })
+
+    -- Add left padding (inline before keyword)
+    if left ~= "" then
+      vim.api.nvim_buf_set_extmark(buf, M.ns, lnum, kw_start, {
+        virt_text = { { left, hl_fg } },
+        virt_text_pos = "inline",
+        priority = 501,
+      })
+    end
+
+    -- Add right padding (inline after keyword)
+    if right ~= "" then
+      vim.api.nvim_buf_set_extmark(buf, M.ns, lnum, kw_end, {
+        virt_text = { { right, hl_fg } },
+        virt_text_pos = "inline",
+        priority = 501,
+      })
+    end
+  end
+
+  -- Handle colon concealing (independent of padding, but respects hide_on_cursor)
+  local hide_colon = padding_config.hide_colon
+  if hide_colon == nil then
+    hide_colon = Config.options.highlight.padding.hide_colon
+  end
+
+  -- Hide colon unless we're on cursor line AND hide_on_cursor is enabled
+  local should_conceal_colon = hide_colon and not (on_cursor_line and Config.options.highlight.padding.hide_on_cursor)
+
+  if should_conceal_colon then
+    local colon_pos = kw_end
+    if line:sub(colon_pos + 1, colon_pos + 1) == ":" then
+      vim.api.nvim_buf_set_extmark(buf, M.ns, lnum, colon_pos, {
+        end_col = colon_pos + 1,
+        conceal = "",
+        priority = 502,
+      })
+    end
+  end
+end
+
+---Clear padding extmarks for a buffer range
+---@param buf number buffer number
+---@param first number first line (0-indexed)
+---@param last number last line (0-indexed, inclusive)
+function M.clear(buf, first, last)
+  vim.api.nvim_buf_clear_namespace(buf, M.ns, first, last + 1)
+end
+
+return M


### PR DESCRIPTION
## Description

This PR implements the ability to optionally surround the keyword with padding characters.

It adds a new `padding` field to the plugin config for padding customization.

Padding is disabled by default for backwards compatibility.

This feature adds value by
- providing users more flexibility to personalize the look-and-feel of their TODO comments
- expanding the ways in which TODO comments can be used / the value they bring.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

Resolves #385

## Screenshots

The following image shows the default padding style (around `TODO`). But this can be overridden globally, or per keyword as demonstrated below.

<img width="378" height="266" alt="image" src="https://github.com/user-attachments/assets/675f350f-c2d0-4cdc-9140-982c253b6721" />

The following clip shows the `hide_on_cursor` feature. If `true` (default), the virtual padding characters disappear when the cursor enters the same line.

https://github.com/user-attachments/assets/87c07b28-48da-4e4a-9634-b3a01a7ea449