### PR TITLE
refactor(search): drop dependency on plenary.nvim

### DIFF
--- a/.neoconf.json
+++ b/.neoconf.json
@@ -2,7 +2,6 @@
   "neodev": {
     "library": {
       "plugins": [
-        "plenary.nvim",
         "nvim-web-devicons",
         "trouble.nvim"
       ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ✅ Todo Comments
 
-**todo-comments** is a lua plugin for Neovim >= 0.8.0 to highlight and search for todo comments like
+**todo-comments** is a lua plugin for Neovim >= 0.10.0 to highlight and search for todo comments like
 `TODO`, `HACK`, `BUG` in your code base.
 
 ![image](https://user-images.githubusercontent.com/292349/118135272-ad21e980-b3b7-11eb-881c-e45a4a3d6192.png)
@@ -16,10 +16,10 @@
 
 ## ⚡️ Requirements
 
-- Neovim >= 0.8.0 (use the `neovim-pre-0.8.0` branch for older versions)
+- Neovim >= 0.10.0
 - a [patched font](https://www.nerdfonts.com/) for the icons, or change them to simple ASCII characters
 - optional:
-  + [ripgrep](https://github.com/BurntSushi/ripgrep) and [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) are used for searching.
+  + [ripgrep](https://github.com/BurntSushi/ripgrep) is used for searching.
   + [Trouble](https://github.com/folke/trouble.nvim)
   + [Telescope](https://github.com/nvim-telescope/telescope.nvim)
   + [FzfLua](https://github.com/ibhagwan/fzf-lua)
@@ -33,7 +33,6 @@ Install the plugin with your preferred package manager:
 ```lua
 {
   "folke/todo-comments.nvim",
-  dependencies = { "nvim-lua/plenary.nvim" },
   opts = {
     -- your configuration comes here
     -- or leave it empty to use the default settings

--- a/doc/todo-comments.nvim.txt
+++ b/doc/todo-comments.nvim.txt
@@ -14,7 +14,7 @@ Table of Contents                       *todo-comments.nvim-table-of-contents*
 ==============================================================================
 1. Todo Comments                            *todo-comments.nvim-todo-comments*
 
-**todo-comments** is a lua plugin for Neovim >= 0.8.0 to highlight and search
+**todo-comments** is a lua plugin for Neovim >= 0.10.0 to highlight and search
 for todo comments like `TODO`, `HACK`, `BUG` in your code base.
 
 
@@ -30,10 +30,10 @@ FEATURES                           *todo-comments.nvim-todo-comments-features*
 
 REQUIREMENTS                   *todo-comments.nvim-todo-comments-requirements*
 
-- Neovim >= 0.8.0 (use the `neovim-pre-0.8.0` branch for older versions)
+- Neovim >= 0.10.0
 - a patched font <https://www.nerdfonts.com/> for the icons, or change them to simple ASCII characters
 - optional:
-    - ripgrep <https://github.com/BurntSushi/ripgrep> and plenary.nvim <https://github.com/nvim-lua/plenary.nvim> are used for searching.
+    - ripgrep <https://github.com/BurntSushi/ripgrep> is used for searching.
     - Trouble <https://github.com/folke/trouble.nvim>
     - Telescope <https://github.com/nvim-telescope/telescope.nvim>
     - FzfLua <https://github.com/ibhagwan/fzf-lua>
@@ -49,7 +49,6 @@ LAZY.NVIM ~
 >lua
     {
       "folke/todo-comments.nvim",
-      dependencies = { "nvim-lua/plenary.nvim" },
       opts = {
         -- your configuration comes here
         -- or leave it empty to use the default settings

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -83,8 +83,8 @@ local defaults = {
 M._options = nil
 
 function M.setup(options)
-  if vim.fn.has("nvim-0.8.0") == 0 then
-    error("todo-comments needs Neovim >= 0.8.0. Use the 'neovim-pre-0.8.0' branch for older versions")
+  if vim.fn.has("nvim-0.10.0") == 0 then
+    error("todo-comments needs Neovim >= 0.10.0")
   end
   M._options = options
   if vim.api.nvim_get_vvar("vim_did_enter") == 0 then

--- a/lua/todo-comments/init.lua
+++ b/lua/todo-comments/init.lua
@@ -6,7 +6,11 @@ local M = {}
 M.setup = config.setup
 
 function M.reset()
-  require("plenary.reload").reload_module("todo")
+  for name, _ in pairs(package.loaded) do
+    if name:match("^todo%-comments") then
+      package.loaded[name] = nil
+    end
+  end
   require("todo-comments").setup()
 end
 

--- a/lua/todo-comments/search.lua
+++ b/lua/todo-comments/search.lua
@@ -59,31 +59,24 @@ function M.search(cb, opts)
     return
   end
 
-  local ok, Job = pcall(require, "plenary.job")
-  if not ok then
-    Util.error("search requires https://github.com/nvim-lua/plenary.nvim")
-    return
-  end
-
   local args = {}
   vim.list_extend(args, Config.options.search.args)
   vim.list_extend(args, { Config.search_regex(keywords_filter(opts.keywords)), opts.cwd })
 
-  Job:new({
-    command = command,
-    args = args,
-    on_exit = vim.schedule_wrap(function(j, code)
-      if code == 2 then
-        local error = table.concat(j:stderr_result(), "\n")
-        Util.error(command .. " failed with code " .. code .. "\n" .. error)
+  vim.system(
+    { command, unpack(args) },
+    { text = true },
+    vim.schedule_wrap(function(obj)
+      if obj.code == 2 then
+        Util.error(command .. " failed with code " .. obj.code .. "\n" .. (obj.stderr or ""))
       end
-      if code == 1 and opts.disable_not_found_warnings ~= true then
+      if obj.code == 1 and opts.disable_not_found_warnings ~= true then
         Util.warn("no todos found")
       end
-      local lines = j:result()
+      local lines = vim.split(obj.stdout or "", "\n", { trimempty = true })
       cb(M.process(lines))
-    end),
-  }):start()
+    end)
+  )
 end
 
 local function parse_opts(opts)


### PR DESCRIPTION
Since plenary library is slated to be archived, refactor the plugin to use vim.system() instead of plenary.job module and implement reset logic in the plugin itself.

Update the documentation and bump up the required neovim version to 0.10.0.

