### PR TITLE
feat(highlight): add case_sensitive option for case-insensitive keyword matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Todo comes with the following defaults:
     keyword = "wide", -- "fg", "bg", "wide", "wide_bg", "wide_fg" or empty. (wide and wide_bg is the same as bg, but will also highlight surrounding characters, wide_fg acts accordingly but with fg)
     after = "fg", -- "fg" or "bg" or empty
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlighting (vim regex)
+    case_sensitive = true, -- use case sensitive matching for keywords
     comments_only = true, -- uses treesitter to match keywords in comments only
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting

--- a/lua/todo-comments/config.lua
+++ b/lua/todo-comments/config.lua
@@ -49,6 +49,7 @@ local defaults = {
     -- pattern can be a string, or a table of regexes that will be checked
     pattern = [[.*<(KEYWORDS)\s*:]], -- pattern or table of patterns, used for highlightng (vim regex)
     -- pattern = { [[.*<(KEYWORDS)\s*:]], [[.*\@(KEYWORDS)\s*]] }, -- pattern used for highlightng (vim regex)
+    case_sensitive = true, -- use case sensitive matching for keywords
     comments_only = true, -- uses treesitter to match keywords in comments only
     max_line_len = 400, -- ignore lines longer than this
     exclude = {}, -- list of file types to exclude highlighting
@@ -109,6 +110,15 @@ function M._setup()
     for _, alt in pairs(opts.alt or {}) do
       M.keywords[alt] = kw
     end
+  end
+
+  -- precomputed uppercase map for case-insensitive keyword lookup.
+  -- when case_sensitive=false, the regex may capture any-case variant (e.g. "todo"),
+  -- this map allows normalizing it back to the key as defined in the config (e.g. "TODO").
+  -- built once at setup to allow O(1) lookup on every highlighted line.
+  M.keywords_upper = {}
+  for k in pairs(M.keywords) do
+    M.keywords_upper[k:upper()] = k
   end
 
   local function tags(keywords)

--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -47,11 +47,20 @@ function M.match(str, patterns)
     patterns = { patterns }
   end
 
+  local case_flag = Config.options.highlight.case_sensitive ~= false and [[\C]] or [[\c]]
   for _, pattern in pairs(patterns) do
-    local m = vim.fn.matchlist(str, [[\v\C]] .. pattern)
+    local m = vim.fn.matchlist(str, [[\v]] .. case_flag .. pattern)
     if #m > 1 and m[2] then
       local match = m[2]
       local kw = m[3] ~= "" and m[3] or m[2]
+      -- when case_sensitive=false, the captured keyword may differ in case from
+      -- the config key (e.g. "todo" vs "TODO") -- normalize via the uppercase map
+      if not Config.keywords[kw] then
+        local normalized = Config.keywords_upper[kw:upper()]
+        if normalized then
+          kw = normalized
+        end
+      end
       local start = str:find(match, 1, true)
       return start, start + #match, kw
     end


### PR DESCRIPTION
## Description

Adds a `highlight.case_sensitive` boolean option (default: `true`) to allow case-insensitive keyword matching for teams that mix styles like `// todo:` and `// TODO:`.

**Before:** users had to manually duplicate keywords as `alt` entries to achieve this:
```lua
TODO = { alt = { "todo", "Todo" } }
```

**After:**
```lua
highlight = {
  case_sensitive = false,
}
```

For search (`:TodoQuickFix`, Telescope, fzf, etc.), case-insensitive matching was already achievable by adding `"--ignore-case"` to `search.args` — this option covers the highlight side consistently.

> **Note:** case-insensitive highlighting was technically already possible by prepending `\c` to a custom `highlight.pattern`, since it overrides the internal `\C` flag. However this relies on undocumented vim regex flag ordering and feels like an unintentional side effect. This PR makes it a documented option.

**Implementation details:**
- `highlight.case_sensitive` controls whether `\C` (strict) or `\c` (insensitive) is used in the vim regex at match time
- A `keywords_upper` map is precomputed once at setup to allow O(1) normalization of any-case captured keywords (e.g. `"todo"`) back to their config key (e.g. `"TODO"`) on every highlighted line

## Related Issue(s)

NA

## Screenshots

<img width="333" height="142" alt="image" src="https://github.com/user-attachments/assets/6a73c01c-2eff-49d3-b7d7-4da12ee3ab57" />