### PR TITLE
fix(highlight): handle Range6 in treesitter changedtree callback. Fixes some items not being highlighted

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -373,7 +373,8 @@ function M.attach(win, force)
         end,
         on_changedtree = function(changes)
           for _, ch in ipairs(changes or {}) do
-            M.invalidate(buf, ch[1], ch[3] + 1)
+            local end_row = (#ch == 6) and ch[4] or ch[3]
+            M.invalidate(buf, ch[1], end_row + 1)
           end
         end,
       })


### PR DESCRIPTION
## Description

The treesitter changedtree callback parameter may be a Range4 or Range6. Currently the code assumes Range4, which causes the 'start bytes' value to be incorrectly used instead of 'end row' when invalidating lines.

This is most noticeable when `comments_only` is true and the changedtree callback is delayed until after the first update. In this case the flow is:
1. First call to highlight() does not highlight anything because is_comment() always returns false (treesitter not ready).
2. changedtree fires, invalidating the wrong range of lines (typically [0, multiline_context]).
3. highlight() only redraws the invalidated line.
4. As a result, most TODOs are not highlighted.