### PR TITLE
fix(highlight): clamp wide keyword end_col to line length

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -243,9 +243,9 @@ function M.highlight(buf, first, last, _event)
 
         -- tag highlights
         if hl.keyword == "wide" or hl.keyword == "wide_bg" then
-          add_highlight(buf, Config.ns, hl_bg, lnum, math.max(start - 1, 0), finish + 1)
+          add_highlight(buf, Config.ns, hl_bg, lnum, math.max(start - 1, 0), math.min(finish + 1, #line))
         elseif hl.keyword == "wide_fg" then
-          add_highlight(buf, Config.ns, hl_fg, lnum, math.max(start - 1, 0), finish + 1)
+          add_highlight(buf, Config.ns, hl_fg, lnum, math.max(start - 1, 0), math.min(finish + 1, #line))
         elseif hl.keyword == "bg" then
           add_highlight(buf, Config.ns, hl_bg, lnum, start, finish)
         elseif hl.keyword == "fg" then


### PR DESCRIPTION
## Summary

Fixes #380.

When `highlight.keyword` is set to one of the wide modes (`wide`, `wide_bg`, `wide_fg`) AND `highlight.pattern` allows a match to end at EOL (e.g. the trailing colon is optional), `nvim_buf_set_extmark` rejects the call with `Invalid 'end_col': out of range`.

The wide branches extend the highlight by one column on each side. The leading side already clamps with `math.max(start - 1, 0)`, but the trailing side passes `finish + 1` unclamped. When the keyword sits at the end of the line, `finish == #line`, so `finish + 1` exceeds the line length. This patch mirrors the existing leading-side clamp using `math.min(finish + 1, #line)`.

The default `pattern` (`[[.*<(KEYWORDS)\s*:]]`) requires a trailing `:`, which is why the bug is latent under stock config and only surfaces with custom patterns.

## My use case

I use `todo-comments.nvim` with the trailing colon made optional, so I can write either `-- TODO: do the thing` or just `-- TODO` at end of line and still get the keyword highlighted while typing. After the recent switch from `nvim_buf_add_highlight` to `nvim_buf_set_extmark` (commit `3434264`), the stricter bounds checking turns the previously-tolerated `finish + 1 > #line` case into a hard error. My config:

```lua
require(\"todo-comments\").setup({
  highlight = {
    keyword = \"wide_fg\",
    pattern = [[.*<(KEYWORDS)\s*:?]],
  },
})
```

Reproduce by opening a buffer and typing `-- TODO` with no trailing characters — the error fires as soon as the keyword completes.

## Why this fix

- Smallest possible diff — two characters added per line, no behavior change for the default config (`finish + 1 ≤ #line` already held there, so `math.min` is a no-op).
- No perf cost (no extra buffer reads).
- Symmetric with the existing `math.max(start - 1, 0)` clamp on the leading side.
- The other `add_highlight` call sites in this function pass `finish` (≤ `#line`) or `#line` directly, both already valid — so the two `wide_*` branches are the only unsafe sites.

A more defensive alternative would be to clamp inside `add_highlight` itself (as suggested in #380), but that costs an extra `nvim_buf_get_lines` call per highlight. I went with the call-site fix; happy to switch approaches if you'd prefer the defensive one.

## Test plan

- [x] With `pattern = [[.*<(KEYWORDS)\s*:?]]` and `keyword = \"wide_fg\"`, the line `-- TODO` alone no longer crashes; keyword highlight renders up to EOL.
- [x] Default config behavior (`pattern = [[.*<(KEYWORDS)\s*:]]`) unchanged.
- [x] `wide`, `wide_bg`, `wide_fg` all behave identically.