### PR TITLE
fix(highlight): reset state when stop

### DIFF
--- a/lua/todo-comments/highlight.lua
+++ b/lua/todo-comments/highlight.lua
@@ -392,6 +392,7 @@ function M.stop()
   pcall(vim.api.nvim_clear_autocmds, { group = "Todo" })
   pcall(vim.api.nvim_del_augroup_by_name, "Todo")
   M.wins = {}
+  M.state = {}
 
   ---@diagnostic disable-next-line: missing-parameter
   vim.fn.sign_unplace("todo-signs")


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Refer to issue #27, we can disable and enable the signs using:
```lua
-- disable signs
require("todo-comments").setup({signs = false})

-- enable signs again
require("todo-comments").setup({signs = true})
```

But the enable will not work because M.stop() not clears M.state, when re-enable, M.get_state(buf) returned the old state where all lines were already marked valid, so M.highlight() never ran to place signs.

Added M.state = {} in M.stop() forces a full re-evaluation of all lines on the next start() → attach(), so the new signs = true setting takes effect.

## Related Issue(s)

- Fixes #27 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->


